### PR TITLE
Add chest_xtion camera in urdf file, add calibration of chest camera with respect to ground floor

### DIFF
--- a/calibrate_chest/CMakeLists.txt
+++ b/calibrate_chest/CMakeLists.txt
@@ -4,7 +4,7 @@ project(calibrate_chest)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs std_msgs)
+find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs std_msgs tf)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -79,6 +79,7 @@ include_directories(
 
 ## Declare a cpp executable
 add_executable(calibrate_chest src/calibrate_chest.cpp)
+add_executable(chest_calibration_publisher src/chest_calibration_publisher.cpp)
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
@@ -86,6 +87,10 @@ add_executable(calibrate_chest src/calibrate_chest.cpp)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(calibrate_chest
+  ${catkin_LIBRARIES} ${PCL_LIBRARIES}
+)
+
+target_link_libraries(chest_calibration_publisher
   ${catkin_LIBRARIES} ${PCL_LIBRARIES}
 )
 

--- a/calibrate_chest/CMakeLists.txt
+++ b/calibrate_chest/CMakeLists.txt
@@ -1,0 +1,138 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(calibrate_chest)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs std_msgs)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+set(PCL_DIR "/opt/ros/groovy/share/pcl-1.6")
+find_package(PCL 1.6 REQUIRED)
+include_directories(${PCL_INCLUDE_DIRS})
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+#######################################
+## Declare ROS messages and services ##
+#######################################
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   sensor_msgs#   std_msgs
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES calibrate_chest
+#  CATKIN_DEPENDS roscpp sensor_msgs std_msgs
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+# include_directories(include)
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a cpp library
+# add_library(calibrate_chest
+#   src/${PROJECT_NAME}/calibrate_chest.cpp
+# )
+
+## Declare a cpp executable
+add_executable(calibrate_chest src/calibrate_chest.cpp)
+
+## Add cmake target dependencies of the executable/library
+## as an example, message headers may need to be generated before nodes
+# add_dependencies(calibrate_chest_node calibrate_chest_generate_messages_cpp)
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(calibrate_chest
+  ${catkin_LIBRARIES} ${PCL_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+# install(TARGETS calibrate_chest calibrate_chest_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_calibrate_chest.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/calibrate_chest/CMakeLists.txt
+++ b/calibrate_chest/CMakeLists.txt
@@ -4,7 +4,7 @@ project(calibrate_chest)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs std_msgs tf)
+find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs std_msgs strands_datacentre)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/calibrate_chest/package.xml
+++ b/calibrate_chest/package.xml
@@ -43,9 +43,11 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>tf</build_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>tf</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/calibrate_chest/package.xml
+++ b/calibrate_chest/package.xml
@@ -43,12 +43,10 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>tf</build_depend>
+  <build_depend>strands_datacentre</build_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
-  <run_depend>tf</run_depend>
-
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/calibrate_chest/package.xml
+++ b/calibrate_chest/package.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<package>
+  <name>calibrate_chest</name>
+  <version>0.0.0</version>
+  <description>The calibrate_chest package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="nbore@todo.todo">nbore</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://ros.org/wiki/calibrate_chest</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>std_msgs</run_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- You can specify that this package is a metapackage here: -->
+    <!-- <metapackage/> -->
+
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/calibrate_chest/src/calibrate_chest.cpp
+++ b/calibrate_chest/src/calibrate_chest.cpp
@@ -72,6 +72,7 @@ void extract_height_and_angle(const Eigen::Vector4f& plane)
     char buffer[250];
     
     // store height above ground in datacentre
+    ros::param::set("/chest_xtion_height", height);
     sprintf(buffer, "{\"path\":\"/chest_xtion_height\",\"value\":%f}", height);
     srv.request.param = buffer;
     if (!client.call(srv)) {
@@ -79,6 +80,7 @@ void extract_height_and_angle(const Eigen::Vector4f& plane)
     }
     
     // store angle between camera and horizontal plane
+    ros::param::set("/chest_xtion_angle", angle);
     sprintf(buffer, "{\"path\":\"/chest_xtion_angle\",\"value\":%f}", angle);
     srv.request.param = buffer;
     if (!client.call(srv)) {

--- a/calibrate_chest/src/calibrate_chest.cpp
+++ b/calibrate_chest/src/calibrate_chest.cpp
@@ -61,7 +61,7 @@ void extract_height_and_angle(const Eigen::Vector4f& plane)
     double height = fabs(plane(3)/plane.segment<3>(0).squaredNorm()); // height
     ROS_INFO("Distance to plane along camera axis: %f", dist);
     ROS_INFO("Height above ground: %f", height);
-    double angle = -asin(height/dist);
+    double angle = asin(height/dist);
     ROS_INFO("Angle radians: %f", angle);
     ROS_INFO("Angle degrees: %f", 180.0f*angle/M_PI);
 }
@@ -128,7 +128,7 @@ int main(int argc, char** argv)
     std::string camera_topic;
     n.getParam("/image_player_node/camera_topic", camera_topic);
     */
-    std::string camera_topic = "head_xtion";
+    std::string camera_topic = "chest_xtion";
     
 	ros::Subscriber sub = n.subscribe(camera_topic + "/depth/points", 1, callback);
     

--- a/calibrate_chest/src/calibrate_chest.cpp
+++ b/calibrate_chest/src/calibrate_chest.cpp
@@ -1,0 +1,138 @@
+#include <ros/ros.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <pcl_ros/point_cloud.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_types.h>
+#include <pcl/visualization/pcl_visualizer.h>
+#include <boost/thread/thread.hpp>
+
+bool is_inlier(const Eigen::Vector3f& point, const Eigen::Vector4f plane, double threshold)
+{
+    return fabs(point.dot(plane.segment<3>(0)) + plane(3)) < threshold;
+}
+
+void plot_best_plane(const pcl::PointCloud<pcl::PointXYZ>& points, const Eigen::Vector4f plane, double threshold)
+{
+    pcl::PointCloud<pcl::PointXYZ>::Ptr inlier_cloud(new pcl::PointCloud<pcl::PointXYZ>());
+    pcl::PointCloud<pcl::PointXYZ>::Ptr outlier_cloud(new pcl::PointCloud<pcl::PointXYZ>());
+    
+    for (int i = 0; i < points.size(); ++i) {
+        if (is_inlier(points[i].getVector3fMap(), plane, threshold)) {
+            inlier_cloud->push_back(points[i]);
+        }
+        else {
+            outlier_cloud->push_back(points[i]);
+        }
+    }
+    
+    pcl::visualization::PCLVisualizer viewer("3D Viewer");
+    viewer.setBackgroundColor(0, 0, 0);
+    viewer.addCoordinateSystem(1.0);
+    viewer.initCameraParameters();
+    
+    pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> inlier_color_handler(inlier_cloud, 255, 0, 0);
+    viewer.addPointCloud(inlier_cloud, inlier_color_handler, "inliers");
+    
+    pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> outlier_color_handler(outlier_cloud, 0, 0, 255);
+    viewer.addPointCloud(outlier_cloud, outlier_color_handler, "outliers");
+    
+    while (!viewer.wasStopped())
+    {
+        viewer.spinOnce(100);
+        boost::this_thread::sleep(boost::posix_time::microseconds(100000));
+    }
+    
+}
+
+void compute_plane(Eigen::Vector4f& plane, const pcl::PointCloud<pcl::PointXYZ>& points, int* inds)
+{
+    Eigen::Vector3f first = points[inds[1]].getVector3fMap() - points[inds[0]].getVector3fMap();
+    Eigen::Vector3f second = points[inds[2]].getVector3fMap() - points[inds[0]].getVector3fMap();
+    Eigen::Vector3f normal = first.cross(second);
+    normal.normalize();
+    plane.segment<3>(0) = normal;
+    plane(3) = -normal.dot(points[inds[0]].getVector3fMap());
+}
+
+void extract_height_and_angle(const Eigen::Vector4f& plane)
+{
+    ROS_INFO("Ground plane: %f, %f, %f, %f", plane(0), plane(1), plane(2), plane(3));
+    double dist = fabs(plane(3)/plane(2)); // distance along z axis
+    double height = fabs(plane(3)/plane.segment<3>(0).squaredNorm()); // height
+    ROS_INFO("Distance to plane along camera axis: %f", dist);
+    ROS_INFO("Height above ground: %f", height);
+    double angle = -asin(height/dist);
+    ROS_INFO("Angle radians: %f", angle);
+    ROS_INFO("Angle degrees: %f", 180.0f*angle/M_PI);
+}
+
+void callback(const sensor_msgs::PointCloud2::ConstPtr& msg)
+{
+    ROS_INFO("Got a pointcloud, calibrating...");
+    pcl::PointCloud<pcl::PointXYZ> cloud;
+    pcl::fromROSMsg(*msg, cloud);
+    
+    int nbr = cloud.size();
+    
+    int max = 1000;
+    double threshold = 0.02;
+    
+    Eigen::Vector4f best_plane;
+    int best_inliers = -1;
+    
+    int inds[3];
+    
+    Eigen::Vector4f plane;
+    int inliers;
+    for (int i = 0; i < max; ++i) {
+        
+        for (int j = 0; j < 3; ++j) {
+            inds[j] = rand() % nbr;
+        }
+        
+        if (inds[0] == inds[1] || inds[0] == inds[2] || inds[1] == inds[2]) {
+            continue;
+        }
+        
+        compute_plane(plane, cloud, inds);
+        inliers = 0;
+        for (int j = 0; j < nbr; j += 30) {
+            if (is_inlier(cloud[j].getVector3fMap(), plane, threshold)) {
+                ++inliers;
+            }
+        }
+        
+        if (inliers > best_inliers) {
+            best_plane = plane;
+            best_inliers = inliers;
+        }
+    }
+    
+    extract_height_and_angle(best_plane);
+    plot_best_plane(cloud, best_plane, threshold);
+    
+    exit(0);
+}
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "calibrate_chest");
+	ros::NodeHandle n;
+	
+	/*
+    // topic of the depth and rgb images
+    if (!n.hasParam("/image_player_node/camera_topic")) {
+        ROS_ERROR("Could not find parameter camera_topic.");
+        return -1;
+    }
+    std::string camera_topic;
+    n.getParam("/image_player_node/camera_topic", camera_topic);
+    */
+    std::string camera_topic = "head_xtion";
+    
+	ros::Subscriber sub = n.subscribe(camera_topic + "/depth/points", 1, callback);
+    
+    ros::spin();
+	
+	return 0;
+}

--- a/calibrate_chest/src/chest_calibration_publisher.cpp
+++ b/calibrate_chest/src/chest_calibration_publisher.cpp
@@ -1,0 +1,27 @@
+#include <ros/ros.h>
+#include <tf/transform_broadcaster.h>
+
+int main(int argc, char** argv) {
+
+    ros::init(argc, argv, "chest_calibration_publisher");
+	ros::NodeHandle n;
+    
+    double height, angle;
+    n.param<double>("/chest_xtion_height", height, 1.10f);
+    n.param<double>("/chest_xtion_angle", angle, 0.72f);
+    
+    std::cout << height << std::endl;
+    std::cout << angle << std::endl;
+    ros::Rate rate(1.0f);
+    
+    while (n.ok()) {
+        static tf::TransformBroadcaster br;
+        tf::Transform transform;
+        transform.setOrigin(tf::Vector3(0.12f, 0.0f, height));
+        transform.setRotation(tf::createQuaternionFromRPY(0.0f, angle, 0.0f));
+        br.sendTransform(tf::StampedTransform(transform, ros::Time::now(), "/base_link", "/chest_xtion_link"));
+        rate.sleep();
+    }
+    
+    return 0;
+}

--- a/calibrate_chest/src/chest_calibration_publisher.cpp
+++ b/calibrate_chest/src/chest_calibration_publisher.cpp
@@ -1,27 +1,41 @@
 #include <ros/ros.h>
-#include <tf/transform_broadcaster.h>
+#include <sensor_msgs/JointState.h>
 
 int main(int argc, char** argv) {
 
     ros::init(argc, argv, "chest_calibration_publisher");
 	ros::NodeHandle n;
     
+    // get calibration with respect to ground plane from the calibrate_chest node
     double height, angle;
-    n.param<double>("/chest_xtion_height", height, 1.10f);
-    n.param<double>("/chest_xtion_angle", angle, 0.72f);
+    n.param<double>("/chest_xtion_height", height, 1.10f); // get the height calibration
+    n.param<double>("/chest_xtion_angle", angle, 0.72f); // get the angle calibration
     
-    std::cout << height << std::endl;
-    std::cout << angle << std::endl;
+    ROS_INFO("Setting height of chest camera: %f", height);
+    ROS_INFO("Setting angle of chest camera: %f", angle);
     ros::Rate rate(1.0f);
     
-    while (n.ok()) {
-        static tf::TransformBroadcaster br;
-        tf::Transform transform;
-        transform.setOrigin(tf::Vector3(0.12f, 0.0f, height));
-        transform.setRotation(tf::createQuaternionFromRPY(0.0f, angle, 0.0f));
-        br.sendTransform(tf::StampedTransform(transform, ros::Time::now(), "/base_link", "/chest_xtion_link"));
+    ros::Publisher pub = n.advertise<sensor_msgs::JointState>("/chest_calibration_publisher/state", 1);
+    
+    int counter = 0; // only publish for the first 10 secs, transforms will stay in tf
+    while (n.ok() && counter < 10) {
+        sensor_msgs::JointState joint_state;
+        joint_state.header.stamp = ros::Time::now();
+        joint_state.name.resize(2);
+        joint_state.position.resize(2);
+        joint_state.velocity.resize(2);
+        joint_state.name[0] = "chest_xtion_height_joint";
+        joint_state.name[1] = "chest_xtion_tilt_joint";
+        joint_state.position[0] = height;
+        joint_state.position[1] = angle;
+        joint_state.velocity[0] = 0;
+        joint_state.velocity[1] = 0;
+        pub.publish(joint_state);
         rate.sleep();
+        ++counter;
     }
+    
+    ROS_INFO("Stopping to publish chest transform after 10 seconds, quitting...");
     
     return 0;
 }

--- a/calibrate_chest/src/chest_calibration_publisher.cpp
+++ b/calibrate_chest/src/chest_calibration_publisher.cpp
@@ -11,8 +11,8 @@ int main(int argc, char** argv) {
     n.param<double>("/chest_xtion_height", height, 1.10f); // get the height calibration
     n.param<double>("/chest_xtion_angle", angle, 0.72f); // get the angle calibration
     
-    ROS_INFO("Setting height of chest camera: %f", height);
-    ROS_INFO("Setting angle of chest camera: %f", angle);
+    //ROS_INFO("Setting height of chest camera: %f", height);
+    //ROS_INFO("Setting angle of chest camera: %f", angle);
     ros::Rate rate(1.0f);
     
     ros::Publisher pub = n.advertise<sensor_msgs::JointState>("/chest_calibration_publisher/state", 1);

--- a/scitos_description/launch/scitos_state_publisher.launch
+++ b/scitos_description/launch/scitos_state_publisher.launch
@@ -7,9 +7,11 @@
     <!-- Joint state publisher to accumulate joints -->
     <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
       <!-- include the pan/tilt unit joint states -->
-      <rosparam param="source_list">[/ptu/state]</rosparam>
+      <rosparam param="source_list">[/ptu/state, /chest_calibration_publisher/state]</rosparam>
     </node>
 
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+    
+    <node pkg="calibrate_chest" type="chest_calibration_publisher" name="chest_calibration_publisher" output="screen"/>
 
 </launch>

--- a/scitos_description/urdf/scitos.xacro
+++ b/scitos_description/urdf/scitos.xacro
@@ -429,14 +429,14 @@
 
   <joint name="chest_xtion_base_link" type="fixed" >
     <origin rpy="0 0 0" 
-            xyz="0 0.045 0" />
+            xyz="0 0 0" />
     <parent link="chest_xtion_link"/>
     <child link="chest_xtion_depth_frame"/>
   </joint>
 
   <joint name="chest_xtion_base_link1" type="fixed" >
     <origin rpy="0 0 0" 
-            xyz="0 0.02 0" />
+            xyz="0 -0.025 0" />
     <parent link="chest_xtion_link"/>
     <child link="chest_xtion_rgb_frame"/>
   </joint>

--- a/scitos_description/urdf/scitos.xacro
+++ b/scitos_description/urdf/scitos.xacro
@@ -416,7 +416,7 @@
 
   <joint name="chest_xtion_joint" type="fixed" >
     <!-- Rotation y angle from calibrate_chest and z height from calibrate_chest -->
-    <origin rpy="0 0.72 0" xyz="0.10 0 1.10" />
+    <origin rpy="0 0.72 0" xyz="0.12 0 1.10" />
     <parent link="base_link"/>
     <child link="chest_xtion_link"/>
   </joint>

--- a/scitos_description/urdf/scitos.xacro
+++ b/scitos_description/urdf/scitos.xacro
@@ -419,7 +419,7 @@
   <joint name="chest_xtion_height_joint" type="prismatic" >
     <!-- Z height from calibrate_chest -->
     <axis xyz="0 0 1"/>
-    <origin rpy="0 0 0" xyz="0.10 0 0" />
+    <origin rpy="0 0 0" xyz="0.12 0 0" />
     <limit effort="1000" velocity="1000" lower="0.5" upper="1.5"/>
     <parent link="base_link"/>
     <child link="chest_xtion_height_tilt_link"/>

--- a/scitos_description/urdf/scitos.xacro
+++ b/scitos_description/urdf/scitos.xacro
@@ -398,4 +398,61 @@
     <child link="head_xtion_rgb_optical_frame"/>
   </joint>
 
+  <!-- Connect base to chest_xtion_link -->
+  <link name="chest_xtion_link">
+    <visual>
+      <origin rpy="3.14 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="package://scitos_description/meshes/xtion.dae"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0.071"/>
+      <geometry>
+        <box size="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <joint name="chest_xtion_joint" type="fixed" >
+    <!-- Rotation y angle from calibrate_chest and z height from calibrate_chest -->
+    <origin rpy="0 0.72 0" xyz="0.10 0 1.10" />
+    <parent link="base_link"/>
+    <child link="chest_xtion_link"/>
+  </joint>
+ 
+  <!-- chest_xtion internal frames -->
+  <link name="chest_xtion_depth_frame"/>
+  <link name="chest_xtion_rgb_frame"/>
+  <link name="chest_xtion_depth_optical_frame"/>
+  <link name="chest_xtion_rgb_optical_frame"/>
+
+  <joint name="chest_xtion_base_link" type="fixed" >
+    <origin rpy="0 0 0" 
+            xyz="0 0.045 0" />
+    <parent link="chest_xtion_link"/>
+    <child link="chest_xtion_depth_frame"/>
+  </joint>
+
+  <joint name="chest_xtion_base_link1" type="fixed" >
+    <origin rpy="0 0 0" 
+            xyz="0 0.02 0" />
+    <parent link="chest_xtion_link"/>
+    <child link="chest_xtion_rgb_frame"/>
+  </joint>
+
+  <joint name="chest_xtion_base_link2" type="fixed" >
+    <origin rpy="-1.5707963267948966 0 -1.5707963267948966" 
+            xyz="0 0 0" />
+    <parent link="chest_xtion_depth_frame"/>
+    <child link="chest_xtion_depth_optical_frame"/>
+  </joint>
+
+  <joint name="chest_xtion_base_link3" type="fixed" >
+    <origin rpy="-1.5707963267948966 0 -1.5707963267948966" 
+            xyz="0 0 0" />
+    <parent link="chest_xtion_rgb_frame"/>
+    <child link="chest_xtion_rgb_optical_frame"/>
+  </joint>
+
 </robot>

--- a/scitos_description/urdf/scitos.xacro
+++ b/scitos_description/urdf/scitos.xacro
@@ -414,7 +414,7 @@
     </collision>
   </link>
 
-  <joint name="chest_xtion_joint" type="fixed" >
+  <joint name="chest_xtion_joint" type="continuous" >
     <!-- Rotation y angle from calibrate_chest and z height from calibrate_chest -->
     <origin rpy="0 0.72 0" xyz="0.12 0 1.10" />
     <parent link="base_link"/>

--- a/scitos_description/urdf/scitos.xacro
+++ b/scitos_description/urdf/scitos.xacro
@@ -413,11 +413,23 @@
       </geometry>
     </collision>
   </link>
+  
+  <link name="chest_xtion_height_tilt_link"/>
 
-  <joint name="chest_xtion_joint" type="continuous" >
-    <!-- Rotation y angle from calibrate_chest and z height from calibrate_chest -->
-    <origin rpy="0 0.72 0" xyz="0.12 0 1.10" />
+  <joint name="chest_xtion_height_joint" type="prismatic" >
+    <!-- Z height from calibrate_chest -->
+    <axis xyz="0 0 1"/>
+    <origin rpy="0 0 0" xyz="0.10 0 0" />
+    <limit effort="1000" velocity="1000" lower="0.5" upper="1.5"/>
     <parent link="base_link"/>
+    <child link="chest_xtion_height_tilt_link"/>
+  </joint>
+  
+  <joint name="chest_xtion_tilt_joint" type="continuous" >
+    <!-- Rotation y angle from calibrate_chest-->
+    <axis xyz="0 1 0"/>
+    <origin rpy="0 0 0" xyz="0 0 0" />
+    <parent link="chest_xtion_height_tilt_link"/>
     <child link="chest_xtion_link"/>
   </joint>
  
@@ -429,14 +441,14 @@
 
   <joint name="chest_xtion_base_link" type="fixed" >
     <origin rpy="0 0 0" 
-            xyz="0 0 0" />
+            xyz="0 0.045 0" />
     <parent link="chest_xtion_link"/>
     <child link="chest_xtion_depth_frame"/>
   </joint>
 
   <joint name="chest_xtion_base_link1" type="fixed" >
     <origin rpy="0 0 0" 
-            xyz="0 -0.025 0" />
+            xyz="0 0.02 0" />
     <parent link="chest_xtion_link"/>
     <child link="chest_xtion_rgb_frame"/>
   </joint>


### PR DESCRIPTION
This commit incorporates the new chest camera in the urdf file. I'm calling it chest_xtion because it's much short than chest_primesense but I can change that if someone objects. This pull incorporates:
- Add chest_xtion in the urdf file
- Calibrate camera with respect to ground floor with calibrate_chest node, store in strands_datacentre
- Launch chest_calibration_publisher node with scitos_state_publisher launch file to publish the height and angle of the camera calculated in calibrate_chest
- The node stops publishing after ten seconds, latest values should remain in tf tree
- To get the latest values you need to have strands_datacentre running before launching scitos_state_publisher or run the calibration node since it will store the values with rosparam

So the question is if this is the right package for these nodes or if we should put them somewhere else. Because calibrate_chest relies on strands_datacentre for storage that's a dependency for building.
