### PR TITLE
Adding robot_pose_publish to scitos_state_publisher.launch

### DIFF
--- a/scitos_description/launch/scitos_state_publisher.launch
+++ b/scitos_description/launch/scitos_state_publisher.launch
@@ -11,7 +11,9 @@
     </node>
 
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
-    
+
+    <node pkg="robot_pose_publisher" type="robot_pose_publisher" name="robot_pose_publisher" />
+
     <node pkg="calibrate_chest" type="chest_calibration_publisher" name="chest_calibration_publisher" output="screen"/>
 
 </launch>


### PR DESCRIPTION
/robot_pose topic is needed by visual_charging node and waypoint_patroller
