### PR TITLE
[calibrate_chest]Fixed dependencies on datacentre

### DIFF
--- a/calibrate_chest/CMakeLists.txt
+++ b/calibrate_chest/CMakeLists.txt
@@ -83,7 +83,7 @@ add_executable(chest_calibration_publisher src/chest_calibration_publisher.cpp)
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
-# add_dependencies(calibrate_chest_node calibrate_chest_generate_messages_cpp)
+add_dependencies(calibrate_chest strands_datacentre_generate_messages_cpp)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(calibrate_chest

--- a/calibrate_chest/package.xml
+++ b/calibrate_chest/package.xml
@@ -1,32 +1,28 @@
 <?xml version="1.0"?>
 <package>
   <name>calibrate_chest</name>
-  <version>0.0.0</version>
-  <description>The calibrate_chest package</description>
+  <version>0.0.1</version>
+  <description>
+    This package contains robot-specific definitions of the SCITOS robot such
+    as the URDF description of the robot's kinematics and dynamics and 3D
+    models of robot components.
+  </description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="nbore@todo.todo">nbore</maintainer>
-
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <maintainer email="nbore@kth.se">Nils Bore</maintainer>
 
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
-
+  <license>BSD</license>
 
   <!-- Url tags are optional, but mutiple are allowed, one per tag -->
   <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://ros.org/wiki/calibrate_chest</url> -->
-
+  <url type="website">http://github.com/strands-project/scitos_common</url>
 
   <!-- Author tags are optional, mutiple are allowed, one per tag -->
   <!-- Authors do not have to be maintianers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
+  <author email="nbore@kth.se">Nils Bore</author>
 
   <!-- The *_depend tags are used to specify dependencies -->
   <!-- Dependencies can be catkin packages or system dependencies -->
@@ -47,6 +43,7 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>strands_datacenre</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/calibrate_chest/package.xml
+++ b/calibrate_chest/package.xml
@@ -3,9 +3,10 @@
   <name>calibrate_chest</name>
   <version>0.0.1</version>
   <description>
-    This package contains robot-specific definitions of the SCITOS robot such
-    as the URDF description of the robot's kinematics and dynamics and 3D
-    models of robot components.
+    This package contains one node that calculates the angle and height
+    between the camera publishing on topic /chest_xtion and the floor.
+    This data is saved in the strands_datacentre and published by another
+    node when starting the robot with the scitos_bringup launch file.
   </description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->


### PR DESCRIPTION
Fixed a bug where all the dependencies on the datacentre where not defined properly which made parallell builds fail and filled out package.xml. This should fix https://github.com/strands-project/scitos_common/issues/28.
