### PR TITLE
Fixed misspelling of ros_datacentre in package.xml

### DIFF
--- a/calibrate_chest/package.xml
+++ b/calibrate_chest/package.xml
@@ -44,7 +44,7 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
-  <run_depend>ros_datacenre</run_depend>
+  <run_depend>ros_datacentre</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
Fix for https://github.com/strands-project/strands_systems/issues/68
