### PR TITLE
Renamed ros_datacentre to mongodb_store

### DIFF
--- a/calibrate_chest/CMakeLists.txt
+++ b/calibrate_chest/CMakeLists.txt
@@ -4,7 +4,7 @@ project(calibrate_chest)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs std_msgs ros_datacentre)
+find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs std_msgs mongodb_store)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -82,7 +82,7 @@ add_executable(chest_calibration_publisher src/chest_calibration_publisher.cpp)
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
-add_dependencies(calibrate_chest ros_datacentre_generate_messages_cpp)
+add_dependencies(calibrate_chest mongodb_store_generate_messages_cpp)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(calibrate_chest

--- a/calibrate_chest/package.xml
+++ b/calibrate_chest/package.xml
@@ -5,7 +5,7 @@
   <description>
     This package contains one node that calculates the angle and height
     between the camera publishing on topic /chest_xtion and the floor.
-    This data is saved in the ros_datacentre and published by another
+    This data is saved in the mongodb_store and published by another
     node when starting the robot with the scitos_bringup launch file.
   </description>
 
@@ -40,11 +40,11 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>ros_datacentre</build_depend>
+  <build_depend>mongodb_store</build_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
-  <run_depend>ros_datacentre</run_depend>
+  <run_depend>mongodb_store</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/calibrate_chest/src/calibrate_chest.cpp
+++ b/calibrate_chest/src/calibrate_chest.cpp
@@ -5,7 +5,7 @@
 #include <pcl/point_types.h>
 #include <pcl/visualization/pcl_visualizer.h>
 #include <boost/thread/thread.hpp>
-#include "ros_datacentre/SetParam.h"
+#include "mongodb_store/SetParam.h"
 
 ros::ServiceClient client;
 
@@ -68,7 +68,7 @@ void extract_height_and_angle(const Eigen::Vector4f& plane)
     ROS_INFO("Angle radians: %f", angle);
     ROS_INFO("Angle degrees: %f", 180.0f*angle/M_PI);
     
-    ros_datacentre::SetParam srv;
+    mongodb_store::SetParam srv;
     char buffer[250];
     
     // store height above ground in datacentre
@@ -143,7 +143,7 @@ int main(int argc, char** argv)
 	ros::NodeHandle n;
 	
     std::string camera_topic = "chest_xtion";
-    client = n.serviceClient<ros_datacentre::SetParam>("/config_manager/set_param");
+    client = n.serviceClient<mongodb_store::SetParam>("/config_manager/set_param");
 	ros::Subscriber sub = n.subscribe(camera_topic + "/depth/points", 1, callback);
     
     ros::spin();


### PR DESCRIPTION
This simply bulk replaces all ros_datacentre strings to mongodb_store strings inside files and also in file names.

Needs strands-project/ros_datacentre#76 to me merged first.
