### PR TITLE
Replacing deprecated xarco include

### DIFF
--- a/scitos_description/urdf/scitos.xacro
+++ b/scitos_description/urdf/scitos.xacro
@@ -7,7 +7,7 @@
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- calibration data -->
-  <include filename="$(find scitos_description)/urdf/scitos_calibration.xacro" />
+  <xacro:include filename="$(find scitos_description)/urdf/scitos_calibration.xacro" />
 
   <!-- materials -->
   <material name="Red">


### PR DESCRIPTION
Gets rid of the stupid warning when launched.
