### PR TITLE
Starting state publisher in robot namespace

### DIFF
--- a/scitos_description/launch/scitos_state_publisher.launch
+++ b/scitos_description/launch/scitos_state_publisher.launch
@@ -8,15 +8,19 @@
     <!-- Robot -->
     <arg name="urdf_file" default="$(find xacro)/xacro.py '$(find scitos_description)/urdf/scitos.xacro'" />
     <param name="robot_description" command="$(arg urdf_file)" />
+    
+    <group ns="robot">
+      <param name="robot_description" command="$(arg urdf_file)" />
 <!--    <param name="robot_description" command="cat $(find scitos_description)/urdf/scitos.urdf"/> -->
 
-    <!-- Joint state publisher to accumulate joints -->
-    <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-      <!-- include the pan/tilt unit joint states -->
-      <rosparam param="source_list">[/ptu/state]</rosparam>
-    </node>
+      <!-- Joint state publisher to accumulate joints -->
+      <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+        <!-- include the pan/tilt unit joint states -->
+        <rosparam param="source_list">[/ptu/state]</rosparam>
+      </node>
 
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+      <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+    </group>
 
     <node pkg="robot_pose_publisher" type="robot_pose_publisher" name="robot_pose_publisher" />
 


### PR DESCRIPTION
After introducing the changes in https://github.com/strands-project/strands_movebase/pull/53 the tf information for everything, except for the chest camera, was published twice. This resulted in the PTU being at the 0 and 60 degree position at the same time if you turned it to 60 degree. We basically had two rivalling tf states. With this change the state publishers are now started in the `robot` namespace and the `/robot_description` will still be read from the xarco file for the robot model in rviz. In addition to that, there is now also the `/robot/robot_description` parameter which is used by the state publishers for the publishing of the tf tree.

This does not change any of the default behaviour but creates a clearer structure and fixes the robot model and the tf tree as can be seen in the PR I'll link below once it is open.
