### PR TITLE
Starting state publisher in separate namespace... for real this time

### DIFF
--- a/scitos_description/launch/scitos_state_publisher.launch
+++ b/scitos_description/launch/scitos_state_publisher.launch
@@ -8,15 +8,19 @@
     <!-- Robot -->
     <arg name="urdf_file" default="$(find xacro)/xacro.py '$(find scitos_description)/urdf/scitos.xacro'" />
     <param name="robot_description" command="$(arg urdf_file)" />
+    
+    <group ns="robot">
+      <param name="robot_description" command="$(arg urdf_file)" />
 <!--    <param name="robot_description" command="cat $(find scitos_description)/urdf/scitos.urdf"/> -->
 
-    <!-- Joint state publisher to accumulate joints -->
-    <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-      <!-- include the pan/tilt unit joint states -->
-      <rosparam param="source_list">[/ptu/state]</rosparam>
-    </node>
+      <!-- Joint state publisher to accumulate joints -->
+      <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+        <!-- include the pan/tilt unit joint states -->
+        <rosparam param="source_list">[/ptu/state]</rosparam>
+      </node>
 
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+      <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+    </group>
 
     <node pkg="robot_pose_publisher" type="robot_pose_publisher" name="robot_pose_publisher" />
 

--- a/scitos_description/urdf/scitos.xacro
+++ b/scitos_description/urdf/scitos.xacro
@@ -7,7 +7,7 @@
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- calibration data -->
-  <include filename="$(find scitos_description)/urdf/scitos_calibration.xacro" />
+  <xacro:include filename="$(find scitos_description)/urdf/scitos_calibration.xacro" />
 
   <!-- materials -->
   <material name="Red">


### PR DESCRIPTION
This now pulls to indigo-devel. Also includes the last PR with `xarco:include` that was also only pulled to hydro-devel. Sorry for that. Both have been tested and worked.
