### PR TITLE
Fix mesh transformations.

### DIFF
--- a/scitos_description/meshes/scitos_1.dae
+++ b/scitos_description/meshes/scitos_1.dae
@@ -1010,13 +1010,11 @@
         <node id="Screen" name="Screen" type="NODE">
           <matrix sid="transform">0.8191519 0 -0.5735766 -0.21 0 1 0 0 0.5735766 0 0.8191519 0.8265 0 0 0 1</matrix>
           <node id="screen_screen" name="screen_screen" type="NODE">
-            <matrix sid="parentinverse">0.8191519 0 0.5735766 -0.3020391 0 1 0 0 -0.5735766 0 0.8191518 -0.79748 0 0 0 1</matrix>
-            <matrix sid="transform">0.09420247 0 -0.001433942 -0.3009106 0 0.1525 0 0 0.06596132 0 0.00204788 0.991092 0 0 0 1</matrix>
+            <matrix sid="transform">0.115000001942 0.0 -2.66181799909e-10 0.0199365899271 0.0 0.1525 0.0 0.0 1.55417400477e-09 0.0 0.00250000016514 0.186970074618 0.0 0.0 0.0 1.0</matrix>
             <instance_geometry url="#Cube_001-mesh"/>
           </node>
           <node id="sc_body1" name="sc_body1" type="NODE">
-            <matrix sid="parentinverse">0.8191519 0 0.5735766 -0.3020391 0 1 0 0 -0.5735766 0 0.8191518 -0.79748 0 0 0 1</matrix>
-            <matrix sid="transform">0.1249207 0 -0.008603648 -0.2911472 0 0.1735 0 -1.06573e-9 0.08747043 0 0.01228728 0.9765648 0 0 0 1</matrix>
+            <matrix sid="transform">0.152500020594 0.0 1.67951679821e-09 0.019601835604 0.0 0.1735 0.0 -1.06573e-09 -3.01943459957e-08 0.0 0.0149999986965 0.169470034812 0.0 0.0 0.0 1.0</matrix>
             <instance_geometry url="#Cube-mesh">
               <bind_material>
                 <technique_common>
@@ -1026,8 +1024,7 @@
             </instance_geometry>
           </node>
           <node id="sc_body2" name="sc_body2" type="NODE">
-            <matrix sid="parentinverse">0.8191519 0 0.5735766 -0.3020391 0 1 0 0 -0.5735766 0 0.8191518 -0.79748 0 0 0 1</matrix>
-            <matrix sid="transform">0.8191519 0 -0.5735766 -0.0994709 0 1 0 -5.63917e-9 0.5735766 0 0.8191519 1.115894 0 0 0 1</matrix>
+            <matrix sid="transform">0.999999951341 0.0 0.0 0.256529809751 0.0 1.0 0.0 -5.63917e-09 -5.73576600105e-08 0.0 0.999999869426 0.17366075933 0.0 0.0 0.0 1.0</matrix>
             <instance_geometry url="#Cylinder_002-mesh">
               <bind_material>
                 <technique_common>
@@ -1037,18 +1034,16 @@
             </instance_geometry>
           </node>
           <node id="sc_body3" name="sc_body3" type="NODE">
-            <matrix sid="parentinverse">0.8191519 0 0.5735766 -0.3020391 0 1 0 0 -0.5735766 0 0.8191518 -0.79748 0 0 0 1</matrix>
-            <matrix sid="transform">0.1105855 0 -0.008603649 -0.2924002 0 0.145 0 0 0.07743285 0 0.01228728 0.9441797 0 0 0 1</matrix>
+            <matrix sid="transform">0.134999993269 0.0 8.60364899116e-10 1.02724639961e-07 0.0 0.145 0.0 0.0 3.35732999734e-09 0.0 0.0149999992701 0.143660413334 0.0 0.0 0.0 1.0</matrix>
             <instance_geometry url="#Cube_002-mesh"/>
           </node>
           <node id="sc_body4" name="sc_body4" type="NODE">
-            <matrix sid="parentinverse">0.8191519 0 0.5735766 -0.3020391 0 1 0 0 -0.5735766 0 0.8191518 -0.79748 0 0 0 1</matrix>
-            <matrix sid="transform">0.8191519 0 -0.5735766 -0.2407783 0 1 0 0 0.5735766 0 0.8191519 0.870456 0 0 0 1</matrix>
+            <matrix sid="transform">0.999999951341 0.0 0.0 9.1005829983e-08 0.0 1.0 0.0 0.0 -5.73576600105e-08 0.0 0.999999869426 0.0536603978886 0.0 0.0 0.0 1.0
+</matrix>
             <instance_geometry url="#Cylinder_003-mesh"/>
           </node>
           <node id="sc_body5" name="sc_body5" type="NODE">
-            <matrix sid="parentinverse">0.8191519 0 0.5735766 -0.3020391 0 1 0 0 -0.5735766 0 0.8191518 -0.79748 0 0 0 1</matrix>
-            <matrix sid="transform">-5.93377e-7 0 1 -0.1892674 0 0.9 0 0 -0.9 0 -5.90933e-7 0.8265001 0 0 0 1</matrix>
+            <matrix sid="transform">-0.516219426066 0.0 0.819151561055 0.0169832669396 0.0 0.9 0.0 0.0 -0.737236279653 0.0 -0.573577084064 -0.011891603602 0.0 0.0 0.0 1.0</matrix>
             <instance_geometry url="#Cylinder_004-mesh"/>
           </node>
         </node>

--- a/scitos_description/meshes/xtion.dae
+++ b/scitos_description/meshes/xtion.dae
@@ -422,21 +422,11 @@
           </bind_material>
         </instance_geometry>
         <node id="Depth" name="Depth" type="NODE">
-          <matrix sid="parentinverse">-470.1033 0.3717329 -1.995e-4 -2.3613e-6 -0.3613067 -456.9181 -1.53319e-7 -2.9851e-6 -1.42586e-4 9.06303e-12 335.9903 3.980893 0 0 0 1</matrix>
-          <translate sid="location">-0.004927372 -0.04727566 7.76134e-4</translate>
-          <rotate sid="rotationZ">0 0 1 -179.9547</rotate>
-          <rotate sid="rotationY">0 1 0 2.09405e-5</rotate>
-          <rotate sid="rotationX">1 0 0 -0.001219419</rotate>
-          <scale sid="scale">0.005791401 0.004022005 0.001991105</scale>
+          <matrix sid="transform">2.72255672172 -0.00215285428879 0.0 2.2987974032 0.00209247198369 2.64619594126 0.0 21.6028820507 8.25772702986e-07 -5.2487641005e-14 0.0 4.24166719807 0.0 0.0 0.0 1.0</matrix>
           <instance_geometry url="#gDepth_001-mesh"/>
         </node>
         <node id="RGB" name="RGB" type="NODE">
-          <matrix sid="parentinverse">-470.1033 0.3717329 -1.995e-4 -2.3613e-6 -0.3613067 -456.9181 -1.53319e-7 -2.9851e-6 -1.42586e-4 9.06303e-12 335.9903 3.980893 0 0 0 1</matrix>
-          <translate sid="location">-0.004913696 -0.01996619 8.12016e-4</translate>
-          <rotate sid="rotationZ">0 0 1 -179.9547</rotate>
-          <rotate sid="rotationY">0 1 0 2.09405e-5</rotate>
-          <rotate sid="rotationX">1 0 0 -0.001219419</rotate>
-          <scale sid="scale">0.005791401 0.004022005 0.001991105</scale>
+          <matrix sid="transform">2.72255672172 -0.00149511158246 0.0 2.30252009179 0.00209247198369 1.83772688279 0.0 9.1246859651 8.25772702986e-07 -3.64515519752e-14 0.0 4.25372320007 0.0 0.0 0.0 1.0</matrix>
           <instance_geometry url="#gRGB_001-mesh"/>
         </node>
       </node>


### PR DESCRIPTION
Closes #57.

This PR adapts the `xtion.dae` and `scitos_1.dae` collada mesh resources so that there is only one transformations in them for each mesh geometry element. This work-around allows the resources to be used in programs that don't check for multiple <matrix> elements when loading collada files. To do this I manually combined the transformations into a single matrix in each problem case.

The reason these two meshes have multiple <matrix> elements is because they were exported from a Blender file that had the objects in a hierarchy not flat. I think it is acceptable collada format to have multiple, but it appears many programs don't read it well if you do. RViz reads either fine.
