### PR TITLE
[BUG] Fix laser transform.

### DIFF
--- a/scitos_description/urdf/scitos_calibration.xacro
+++ b/scitos_description/urdf/scitos_calibration.xacro
@@ -2,9 +2,9 @@
 <robot name="scitosA5" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- calibration params -->
   <!-- front laser -->
-  <property name="front_laser_scan_trans_x" value="0.07" />
+  <property name="front_laser_scan_trans_x" value="0.109" />
   <property name="front_laser_scan_trans_y" value="0" />
-  <property name="front_laser_scan_trans_z" value="0.365" />
+  <property name="front_laser_scan_trans_z" value="0.385" />
   <property name="front_laser_scan_rot_x" value="0.0" />
   <property name="front_laser_scan_rot_y" value="0.0" />
   <property name="front_laser_scan_rot_z" value="0.0" />


### PR DESCRIPTION
The transform in the URDF for the laser pose is wrong by 4cm. This will have had a negative effect on localisation and on path following.

There are still problems with the DWA path following after this fix, particularly trying to go through doors.

I am reasonably certain that this new transform is correct, but have only checked it by eye...
