### PR TITLE
Don't round laser pose.

### DIFF
--- a/scitos_description/urdf/scitos_calibration.xacro
+++ b/scitos_description/urdf/scitos_calibration.xacro
@@ -2,9 +2,9 @@
 <robot name="scitosA5" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- calibration params -->
   <!-- front laser -->
-  <property name="front_laser_scan_trans_x" value="0.109" />
+  <property name="front_laser_scan_trans_x" value="0.1094" />
   <property name="front_laser_scan_trans_y" value="0" />
-  <property name="front_laser_scan_trans_z" value="0.385" />
+  <property name="front_laser_scan_trans_z" value="0.3848" />
   <property name="front_laser_scan_rot_x" value="0.0" />
   <property name="front_laser_scan_rot_y" value="0.0" />
   <property name="front_laser_scan_rot_z" value="0.0" />


### PR DESCRIPTION
As detailed in #59, the corrected laser pose was rounded to nearest mm. This PR adds the extra decimal place to match exactly the MetraLabs specification.
